### PR TITLE
Add LED control (`on`/`off`)

### DIFF
--- a/asusrouter/__init__.py
+++ b/asusrouter/__init__.py
@@ -8,6 +8,7 @@ from .error import (
     AsusRouterLoginError,
     AsusRouterLoginBlockError,
     AsusRouterResponseError,
+    AsusRouterServiceError,
     AsusRouterValueError,
     AsusRouterSSLError,
     AsusRouterIdentityError,

--- a/asusrouter/const.py
+++ b/asusrouter/const.py
@@ -1,7 +1,7 @@
 """AsusRouter constants module"""
 
 from asusrouter.dataclass import Key
-from asusrouter.util.converters import bool_from_any, int_from_str, float_from_str, time_from_delta, service_support
+from asusrouter.util.converters import bool_from_any, exists_or_not, int_from_str, float_from_str, time_from_delta, service_support
 
 #Use the last known working Android app user-agent, so the device will reply
 #AR_USER_AGENT = "asusrouter-Android-DUTUtil-1.0.0.255"
@@ -47,6 +47,7 @@ AR_DEVICE_IDENTITY : tuple[Key, ...] = (
     Key("extendno", "fw_build"),
     Key("rc_support", "services", method = service_support),
     Key("ss_support", "services", method = service_support),
+    Key("led_val", "led", method = exists_or_not)
 )
 
 AR_DEVICE_ATTRIBUTES_LIST : tuple[Key, ...] = (
@@ -150,6 +151,7 @@ AR_ERROR = {
 
 ERROR_IDENTITY = "Cannot obtain identity from the device {}. Exception summary{}"
 ERROR_PARSING = "Failed parsing value '{}'. Please report this issue. Exception summary: {}"
+ERROR_SERVICE = "Error calling service '{}'. Service did not return any expected value in the reply: {}"
 ERROR_VALUE = "Wrong value '{}' with original exception: {}"
 ERROR_VALUE_TYPE = "Wrong value '{}' of type {}"
 ERROR_ZERO_DIVISION = "Zero division allert: {}"

--- a/asusrouter/dataclass.py
+++ b/asusrouter/dataclass.py
@@ -43,6 +43,7 @@ class AsusDevice:
     fw_minor : str | None = None
     fw_build : str | None = None
     services : str | None = None
+    led : bool = False
 
 
     def firmware(self) -> str:

--- a/asusrouter/error.py
+++ b/asusrouter/error.py
@@ -56,6 +56,10 @@ class AsusRouterResponseError(AsusRouterError, aiohttp.ClientResponseError):
     """Error on communication"""
 
 
+class AsusRouterServiceError(AsusRouterError):
+    """Error on calling a service"""
+
+
 class AsusRouterValueError(AsusRouterError, ValueError):
     """Invalid value received"""
 

--- a/asusrouter/util/converters.py
+++ b/asusrouter/util/converters.py
@@ -7,8 +7,8 @@ import re
 
 from asusrouter.error import AsusRouterValueError
 
-BOOL_FALSE : tuple[str, ...] = ("false", "block", "0", )
-BOOL_TRUE : tuple[str, ...] = ("true", "allow", "1", )
+BOOL_FALSE : tuple[str, ...] = ("false", "block", "0", "off", )
+BOOL_TRUE : tuple[str, ...] = ("true", "allow", "1", "on", )
 ERROR_VALUE = "Wrong value: {} with original exception: {}"
 ERROR_VALUE_TYPE = "Wrong value {} of type {}"
 REGEX_MAC = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})")
@@ -75,6 +75,15 @@ def bool_from_any(raw : str | int | float) -> bool:
         raise AsusRouterValueError(ERROR_VALUE_TYPE.format(raw, type(raw)))
 
 
+def int_from_bool(raw : bool) -> int:
+    """Convert boolean value to 0 or 1"""
+
+    if type(raw) != bool:
+        raise AsusRouterValueError(ERROR_VALUE_TYPE.format(raw, type(raw)))
+
+    return 1 if raw else 0
+
+
 def none_or_str(raw : str) -> str | None:
     """Returns either string or None if string is empty"""
 
@@ -85,6 +94,18 @@ def none_or_str(raw : str) -> str | None:
         return None
 
     return raw.strip()
+
+
+def exists_or_not(raw : str) -> bool:
+    """Returns whether value exists or is empty"""
+
+    if type(raw) != str:
+        raise AsusRouterValueError(ERROR_VALUE_TYPE.format(raw, type(raw)))
+
+    if raw.strip() == str():
+        return False
+
+    return True
 
 
 def timedelta_long(raw : str) -> timedelta:


### PR DESCRIPTION
New methods for `AsusRouter`:
- `async_service_led_set(value)` - sets the state for LEDs. Returns `True` if change was accepted and `False` if not
- `async_service_led_get()` - returns state of LEDs (`True`/`False` or `None` if LED control is not supported)

New `led` property in `AsusDevice` class and identity as flag of available LED control