### PR TITLE
Remove `async_get_temperature_labels` method

### DIFF
--- a/asusrouter/asusrouter.py
+++ b/asusrouter/asusrouter.py
@@ -1055,18 +1055,6 @@ class AsusRouter:
 
         return self._monitor_misc[KEY_TEMPERATURE]
 
-    async def async_get_temperature_labels(self) -> list[str]:
-        """Return list of temperature sensors"""
-
-        if not self._monitor_misc.ready:
-            await self.async_monitor_misc()
-
-        result = list()
-        for value in self._monitor_misc[KEY_TEMPERATURE]:
-            result.append(value)
-
-        return result
-
     async def async_get_vpn(self, use_cache: bool = True) -> dict[str, Any]:
         """Return VPN status"""
 


### PR DESCRIPTION
This method can be completely replaced using `async_get_temperature` (returning dictionary):

- call the method
- use the dict `keys()` method