### PR TITLE
Remove `async_get_ram_labels` method

### DIFF
--- a/asusrouter/asusrouter.py
+++ b/asusrouter/asusrouter.py
@@ -1005,18 +1005,6 @@ class AsusRouter:
 
         return result
 
-    async def async_get_ram_labels(self) -> list[str]:
-        """Return list of CPU cores"""
-
-        if not self._monitor_main.ready:
-            await self.async_monitor_main()
-
-        result = list()
-        for value in self._monitor_main[KEY_RAM]:
-            result.append(value)
-
-        return result
-
     async def async_get_sysinfo(self, use_cache: bool = True) -> dict[str, Any]:
         """Return sysinfo status"""
 


### PR DESCRIPTION
The same functionality can be obtained from the `async_get_ram` method