### PR TITLE
Show `0` as `build_more` for the shorted FW builds

### DIFF
--- a/asusrouter/util/parsers.py
+++ b/asusrouter/util/parsers.py
@@ -598,7 +598,9 @@ def firmware_string(raw: str) -> Firmware:
 
     minor = int(string[2])
     build = int(string[3])
-    if string[4] and string[4].isdigit():
+    if not string[4]:
+        build_more = 0
+    elif string[4].isdigit():
         build_more = int(string[4])
     else:
         build_more = string[4]


### PR DESCRIPTION
Helps with https://github.com/Vaskivskyi/ha-asusrouter/issues/467#issuecomment-1399229835