### PR TITLE
Add VPNC parsing support for `l2pt`, `pptp`, `surfshark`

### DIFF
--- a/asusrouter/modules/endpoint/hook.py
+++ b/asusrouter/modules/endpoint/hook.py
@@ -534,8 +534,12 @@ def process_vpnc(data: dict[str, Any]) -> Tuple[dict[AsusVPNType, dict[int, Any]
 
     # Re-sort the data by VPN type / id
     vpn: dict[AsusVPNType, dict[int, Any]] = {
+        AsusVPNType.L2TP: {},
         AsusVPNType.OPENVPN: {},
+        AsusVPNType.PPTP: {},
+        AsusVPNType.SURFSHARK: {},
         AsusVPNType.WIREGUARD: {},
+        AsusVPNType.UNKNOWN: {},
     }
 
     for vpnc_id, info in vpnc.items():
@@ -560,6 +564,10 @@ def process_vpnc(data: dict[str, Any]) -> Tuple[dict[AsusVPNType, dict[int, Any]
                 "state": AsusVPNC.UNKNOWN,
                 "error": AccessError.NO_ERROR,
             }
+
+    # Remove UNKNOWN VPN type if it's empty
+    if not vpn[AsusVPNType.UNKNOWN]:
+        vpn.pop(AsusVPNType.UNKNOWN, None)
 
     return vpn, vpnc_clientlist
 

--- a/asusrouter/modules/vpnc.py
+++ b/asusrouter/modules/vpnc.py
@@ -34,7 +34,10 @@ class AsusVPNType(str, Enum):
     """Asus VPN Fusion type."""
 
     UNKNOWN = "Unknown"
+    L2TP = "L2TP"
     OPENVPN = "OpenVPN"
+    PPTP = "PPTP"
+    SURFSHARK = "Surfshark"
     WIREGUARD = "WireGuard"
 
 

--- a/tests/test_data/rt_ax88u_merlin_388/hook_005.py
+++ b/tests/test_data/rt_ax88u_merlin_388/hook_005.py
@@ -13,6 +13,7 @@ expected_result = {
         5: {"state": AsusVPNC.UNKNOWN, "error": AccessError.NO_ERROR},
     },
     AsusData.VPNC: {
+        AsusVPNType.L2TP: {},
         AsusVPNType.OPENVPN: {
             1: {"state": AsusVPNC.UNKNOWN, "error": AccessError.NO_ERROR},
             2: {"state": AsusVPNC.UNKNOWN, "error": AccessError.NO_ERROR},
@@ -20,6 +21,8 @@ expected_result = {
             4: {"state": AsusVPNC.UNKNOWN, "error": AccessError.NO_ERROR},
             5: {"state": AsusVPNC.UNKNOWN, "error": AccessError.NO_ERROR},
         },
+        AsusVPNType.PPTP: {},
+        AsusVPNType.SURFSHARK: {},
         AsusVPNType.WIREGUARD: {
             5: {
                 "state": True,


### PR DESCRIPTION
This allows to receive VPNC data for all the currently known VPN types via `AsusData.VPNC`

This does NOT add support to set the states

Will fix issue https://github.com/Vaskivskyi/ha-asusrouter/issues/726