### PR TITLE
Remove code duplication in generic endpoint `read`

### DIFF
--- a/asusrouter/modules/endpoint/aura.py
+++ b/asusrouter/modules/endpoint/aura.py
@@ -2,15 +2,4 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from asusrouter.tools.readers import read_json_content
-
-
-def read(content: str) -> dict[str, Any]:
-    """Read aura data"""
-
-    # Read the json content
-    aura: dict[str, Any] = read_json_content(content)
-
-    return aura
+from asusrouter.tools.readers import read_json_content as read  # noqa: F401

--- a/asusrouter/modules/endpoint/command.py
+++ b/asusrouter/modules/endpoint/command.py
@@ -2,15 +2,4 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from asusrouter.tools.readers import read_json_content
-
-
-def read(content: str) -> dict[str, Any]:
-    """Read state data"""
-
-    # Read the json content
-    command: dict[str, Any] = read_json_content(content)
-
-    return command
+from asusrouter.tools.readers import read_json_content as read  # noqa: F401

--- a/asusrouter/modules/endpoint/hook.py
+++ b/asusrouter/modules/endpoint/hook.py
@@ -39,7 +39,8 @@ from asusrouter.tools.converters import (
     safe_usage,
     safe_usage_historic,
 )
-from asusrouter.tools.readers import merge_dicts, read_json_content
+from asusrouter.tools.readers import merge_dicts
+from asusrouter.tools.readers import read_json_content as read  # noqa: F401
 
 from .hook_const import (
     MAP_NETWORK,
@@ -57,14 +58,6 @@ REQUIRE_HISTORY = True
 REQUIRE_WLAN = True
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def read(content: str) -> dict[str, Any]:
-    """Read hook data"""
-
-    hook: dict[str, Any] = read_json_content(content)
-
-    return hook
 
 
 def process(data: dict[str, Any]) -> dict[AsusData, Any]:

--- a/asusrouter/modules/endpoint/network.py
+++ b/asusrouter/modules/endpoint/network.py
@@ -5,16 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from asusrouter.modules.data import AsusData
-from asusrouter.tools.readers import read_json_content
-
-
-def read(content: str) -> dict[str, Any]:
-    """Read port status data"""
-
-    # Read the page content
-    port_status: dict[str, Any] = read_json_content(content)
-
-    return port_status
+from asusrouter.tools.readers import read_json_content as read  # noqa: F401
 
 
 def process(data: dict[str, Any]) -> dict[AsusData, Any]:

--- a/asusrouter/modules/endpoint/port_status.py
+++ b/asusrouter/modules/endpoint/port_status.py
@@ -19,18 +19,9 @@ from asusrouter.tools.converters import (
     safe_bool,
     safe_int,
 )
-from asusrouter.tools.readers import read_json_content
+from asusrouter.tools.readers import read_json_content as read  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def read(content: str) -> dict[str, Any]:
-    """Read port status data"""
-
-    # Read the page content
-    port_status: dict[str, Any] = read_json_content(content)
-
-    return port_status
 
 
 def process(data: dict[str, Any]) -> dict[AsusData, Any]:
@@ -57,10 +48,12 @@ def process(data: dict[str, Any]) -> dict[AsusData, Any]:
 
             for port, values in info.items():
                 # Process the port info
-                port_description, port_type, port_id = process_port_info(port, values)
+                port_description, port_type, port_id = process_port_info(
+                    port, values
+                )
 
                 # Create a port type group if it doesn't exist yet
-                if not port_type in ports[mac]:
+                if port_type not in ports[mac]:
                     ports[mac][port_type] = {}
 
                 # Save the port info
@@ -99,7 +92,9 @@ def process_port_info(
     port_id = safe_int(port[1])
 
     # Get the capabilities of the port
-    port_capabilities = int_as_capabilities(safe_int(values.get("cap")), PortCapability)
+    port_capabilities = int_as_capabilities(
+        safe_int(values.get("cap")), PortCapability
+    )
 
     # Get the port type
     port_type = PortType.UNKNOWN
@@ -148,7 +143,9 @@ def process_port_info(
 
     # Leave only the capabilities that are available
     capabilities = [
-        capability for capability, value in port_capabilities.items() if value is True
+        capability
+        for capability, value in port_capabilities.items()
+        if value is True
     ]
 
     # Combine the port description

--- a/tests/modules/endpoint/_test_default.py
+++ b/tests/modules/endpoint/_test_default.py
@@ -1,0 +1,12 @@
+"""Tests for the default endpoint module."""
+
+from typing import Any, Callable
+
+from asusrouter.tools.readers import read_json_content
+
+
+def _test_read(read: Callable[[str], dict[str, Any]]):
+    """Test read function."""
+
+    # Check if 'read' is the same as 'read_json_content'
+    assert read == read_json_content

--- a/tests/modules/endpoint/test_command.py
+++ b/tests/modules/endpoint/test_command.py
@@ -1,27 +1,11 @@
 """Test AsusRouter command endpoint module."""
 
-from unittest.mock import patch
+from asusrouter.modules.endpoint.command import read
 
-from asusrouter.modules.endpoint import command
+from ._test_default import _test_read
 
 
 def test_read():
     """Test read function."""
 
-    # Test data
-    content = '{"key1": "value1", "key2": "value2"}'
-    expected_command = {"key1": "value1", "key2": "value2"}
-
-    # Mock the read_json_content function
-    with patch(
-        "asusrouter.modules.endpoint.command.read_json_content",
-        return_value=expected_command,
-    ) as mock_read_json_content:
-        # Call the function
-        result = command.read(content)
-
-        # Check the result
-        assert result == expected_command
-
-        # Check that read_json_content was called with the correct argument
-        mock_read_json_content.assert_called_once_with(content)
+    _test_read(read)

--- a/tests/modules/endpoint/test_hook.py
+++ b/tests/modules/endpoint/test_hook.py
@@ -1,6 +1,6 @@
-"""Tests for the Aura endpoint module."""
+"""Tests for the Hook endpoint module."""
 
-from asusrouter.modules.endpoint.aura import read
+from asusrouter.modules.endpoint.hook import read
 
 from ._test_default import _test_read
 

--- a/tests/modules/endpoint/test_network.py
+++ b/tests/modules/endpoint/test_network.py
@@ -1,6 +1,6 @@
-"""Tests for the Aura endpoint module."""
+"""Tests for the Network endpoint module."""
 
-from asusrouter.modules.endpoint.aura import read
+from asusrouter.modules.endpoint.network import read
 
 from ._test_default import _test_read
 

--- a/tests/modules/endpoint/test_port_status.py
+++ b/tests/modules/endpoint/test_port_status.py
@@ -1,6 +1,6 @@
-"""Tests for the Aura endpoint module."""
+"""Tests for the Port Status endpoint module."""
 
-from asusrouter.modules.endpoint.aura import read
+from asusrouter.modules.endpoint.port_status import read
 
 from ._test_default import _test_read
 


### PR DESCRIPTION
Since several endpoint modules just reimport `read_json_content` from `tools.readers` and then use it as `read`, there is no need to complicate the code and a direct import should be a better option