### PR TITLE
Add AsusData.DSL for dsllog_dataratedown/up

### DIFF
--- a/asusrouter/modules/data.py
+++ b/asusrouter/modules/data.py
@@ -49,7 +49,7 @@ class AsusData(str, Enum):
     WIREGUARD_CLIENT = "wireguard_client"
     WIREGUARD_SERVER = "wireguard_server"
     WLAN = "wlan"
-
+    DSL = "dsl"
 
 @dataclass
 class AsusDataState:

--- a/asusrouter/modules/data_finder.py
+++ b/asusrouter/modules/data_finder.py
@@ -130,6 +130,10 @@ ASUSDATA_NVRAM = {
         for key, _, _ in [converters.safe_unpack_keys(element)]
         if key != "get_wgsc_status"
     ],
+    "dsl": [
+        "dsllog_dataratedown",
+        "dsllog_datarateup",
+    ]
 }
 ASUSDATA_NVRAM["aura"].extend([f"ledg_rgb{num}" for num in range(0, 8)])
 ASUSDATA_NVRAM["vpnc"].extend(
@@ -255,6 +259,10 @@ ASUSDATA_MAP: dict[AsusData, AsusData | AsusDataFinder] = {
         Endpoint.HOOK,
         method=wlan_nvram_request,
         arguments=AsusRouterAttribute.WLAN_LIST,
+    ),
+    AsusData.DSL: AsusDataFinder(
+        Endpoint.HOOK,
+        nvram=ASUSDATA_NVRAM["dsl"],
     ),
 }
 

--- a/asusrouter/modules/endpoint/hook.py
+++ b/asusrouter/modules/endpoint/hook.py
@@ -744,18 +744,22 @@ def process_wlan(
 def process_dsl(dsl_info: dict[str, Any]) -> dict[str, Any]:
     """Process DSL data"""
 
+    def remove_units(value: Optional[str]) -> Optional[str]:
+        """Remove units from the value."""
+
+        if value is None:
+            return None
+        return value.split(" ")[0]
+
     dsl: dict[str, Any] = {}
 
     # Data preprocessing
-    if "Kbps" in dsl_info.get("dsllog_dataratedown", ""):
-        dsl_info["dsllog_dataratedown"] = dsl_info["dsllog_dataratedown"].replace("Kbps", "")
+    _dataratedown = remove_units(dsl_info.get("dsllog_dataratedown"))
+    _datarateup = remove_units(dsl_info.get("dsllog_datarateup"))
 
-    if "Kbps" in dsl_info.get("dsllog_datarateup", ""):
-        dsl_info["dsllog_datarateup"] = dsl_info["dsllog_datarateup"].replace("Kbps", "")
-
-    dsl = {
-        "dsllog_dataratedown": safe_int(dsl_info["dsllog_dataratedown"], 0),
-        "dsllog_datarateup": safe_int(dsl_info["dsllog_datarateup"], 0),
+    dsl["datarate"] = {
+        "down": safe_int(_dataratedown, 0),
+        "up": safe_int(_datarateup, 0),
     }
 
     return dsl

--- a/asusrouter/modules/endpoint/hook.py
+++ b/asusrouter/modules/endpoint/hook.py
@@ -754,8 +754,8 @@ def process_dsl(dsl_info: dict[str, Any]) -> dict[str, Any]:
         dsl_info["dsllog_datarateup"] = dsl_info["dsllog_datarateup"].replace("Kbps", "")
 
     dsl = {
-        "dsllog_dataratedown": safe_int(dsl_info["dsllog_dataratedown"]),
-        "dsllog_datarateup": safe_int(dsl_info["dsllog_datarateup"]),
+        "dsllog_dataratedown": safe_int(dsl_info["dsllog_dataratedown"], 0),
+        "dsllog_datarateup": safe_int(dsl_info["dsllog_datarateup"], 0),
     }
 
     return dsl

--- a/asusrouter/modules/endpoint/hook.py
+++ b/asusrouter/modules/endpoint/hook.py
@@ -163,6 +163,13 @@ def process(data: dict[str, Any]) -> dict[AsusData, Any]:
         or "wl3_wpa_psk" in data
     ):
         state[AsusData.WLAN] = process_wlan(data, wlan)
+    
+    # DSL
+    if (
+        "dsllog_dataratedown" in data
+        or "dsllog_datarateup" in data
+    ):
+        state[AsusData.DSL] = process_dsl(data)
 
     return state
 
@@ -733,3 +740,22 @@ def process_wlan(
         wlan[interface.value] = info
 
     return wlan
+
+def process_dsl(dsl_info: dict[str, Any]) -> dict[str, Any]:
+    """Process DSL data"""
+
+    dsl: dict[str, Any] = {}
+
+    # Data preprocessing
+    if "Kbps" in dsl_info.get("dsllog_dataratedown", ""):
+        dsl_info["dsllog_dataratedown"] = dsl_info["dsllog_dataratedown"].replace("Kbps", "")
+
+    if "Kbps" in dsl_info.get("dsllog_datarateup", ""):
+        dsl_info["dsllog_datarateup"] = dsl_info["dsllog_datarateup"].replace("Kbps", "")
+
+    dsl = {
+        "dsllog_dataratedown": safe_int(dsl_info["dsllog_dataratedown"]),
+        "dsllog_datarateup": safe_int(dsl_info["dsllog_datarateup"]),
+    }
+
+    return dsl


### PR DESCRIPTION
Get the dsl data from nvram which metioned in ha-asusrouter repo [#837](https://github.com/Vaskivskyi/ha-asusrouter/issues/837).

As there is an API `ajax_AdslStatus.asp`, but the data format is difficult to process.