### PR TITLE
Define DSL models by `Endpoint.DSL`

### DIFF
--- a/asusrouter/asusrouter.py
+++ b/asusrouter/asusrouter.py
@@ -277,6 +277,10 @@ class AsusRouter:
                 remove_data_rule(AsusData.WIREGUARD_CLIENT)
                 remove_data_rule(AsusData.WIREGUARD_SERVER)
 
+            # DSL connection
+            if self._identity.dsl is False:
+                remove_data_rule(AsusData.DSL)
+
             # Ookla Speedtest
             if self._identity.ookla is False:
                 remove_data_rule(AsusData.SPEEDTEST)

--- a/asusrouter/modules/data.py
+++ b/asusrouter/modules/data.py
@@ -20,6 +20,7 @@ class AsusData(str, Enum):
     CLIENTS = "clients"
     CPU = "cpu"
     DEVICEMAP = "devicemap"
+    DSL = "dsl"
     FIRMWARE = "firmware"
     FIRMWARE_NOTE = "firmware_note"
     FLAGS = "flags"
@@ -49,7 +50,7 @@ class AsusData(str, Enum):
     WIREGUARD_CLIENT = "wireguard_client"
     WIREGUARD_SERVER = "wireguard_server"
     WLAN = "wlan"
-    DSL = "dsl"
+
 
 @dataclass
 class AsusDataState:

--- a/asusrouter/modules/endpoint/__init__.py
+++ b/asusrouter/modules/endpoint/__init__.py
@@ -22,6 +22,7 @@ class Endpoint(str, Enum):
     """Endpoint enum. These endpoints are used to receive data from the device."""
 
     DEVICEMAP = "ajax_status.xml"
+    DSL = "ajax_AdslStatus.asp"
     ETHERNET_PORTS = "ajax_ethernet_ports.asp"
     FIRMWARE = "detect_firmware.asp"
     FIRMWARE_NOTE = "release_note0.asp"

--- a/asusrouter/modules/identity.py
+++ b/asusrouter/modules/identity.py
@@ -81,6 +81,7 @@ class AsusDevice:  # pylint: disable=too-many-instance-attributes
     # Flags for device features
     aura: bool = False
     aura_zone: int = 0
+    dsl: bool = False
     led: bool = False
     ookla: bool = False
     vpn_status: bool = False
@@ -128,6 +129,11 @@ async def collect_identity(
     this_device = onboarding.get(identity["mac"])
     if isinstance(this_device, AiMeshDevice):
         identity["model"] = this_device.model
+
+    # Check if DSL
+    if endpoints[Endpoint.DSL] is True:
+        identity["dsl"] = True
+        _LOGGER.debug("DSL-compatible device detected")
 
     # Check if Merlin
     if endpoints[Endpoint.SYSINFO] is True:


### PR DESCRIPTION
- Add `Endpoint.DSL` enum member
- Add the `AsusDevice.dsl` property to the device identity. Set it `True` only if `Endpoint.DSL` is available on the device
- If the device is non-DSL, block the fetching of DSL data

As a result, we'll avoid fetching DSL data when it's anyway not available. This will also return an empty dict on such requests instead of many 0 or None values - this would help in HA and just to make sure the data makes sense