### PR TITLE
Force `Endpoint.PORT_STATUS` to be queued as `GET`

### DIFF
--- a/asusrouter/modules/endpoint/__init__.py
+++ b/asusrouter/modules/endpoint/__init__.py
@@ -75,6 +75,7 @@ EndpointType = Union[Endpoint, EndpointControl, EndpointService, EndpointTools]
 
 # Force request type for the endpoint
 ENDPOINT_FORCE_REQUEST = {
+    Endpoint.PORT_STATUS: RequestType.GET,
     EndpointTools.NETWORK: RequestType.GET,
 }
 


### PR DESCRIPTION
This should fix issues with some older devices when using `POST` to check the non-existing `PORT_STATUS` endpoint resulted in the aiolhttp issues.

Confirmed and fixed on RT-AC66U

Should help with others, probably here as well https://github.com/Vaskivskyi/ha-asusrouter/issues/933