### PR TITLE
Improve the config module

### DIFF
--- a/asusrouter/config.py
+++ b/asusrouter/config.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 import threading
+from enum import StrEnum
 from typing import Any, Callable, Dict, Optional
 
 from asusrouter.tools.converters import safe_bool
+
+
+class ARConfigKey(StrEnum):
+    """Configuration keys for AsusRouter."""
+
+    OPTIMISTIC_DATA = "optimistic_data"
+    OPTIMISTIC_TEMPERATURE = "optimistic_temperature"
+    ROBUST_BOOTTIME = "robust_boottime"
+
 
 CONFIG_DEFAULT_BOOL: bool = False
 
@@ -21,28 +31,45 @@ def safe_bool_config(value: Any) -> bool:
     return config_value
 
 
+CONFIG_DEFAULT: Dict[ARConfigKey, Any] = {
+    ARConfigKey.OPTIMISTIC_DATA: CONFIG_DEFAULT_BOOL,
+    ARConfigKey.OPTIMISTIC_TEMPERATURE: CONFIG_DEFAULT_BOOL,
+    # If set, the boottime will be processed with 2 seconds
+    # precision to avoid +- 1 second uncertainty in the raw data.
+    ARConfigKey.ROBUST_BOOTTIME: CONFIG_DEFAULT_BOOL,
+}
+
+TYPES_DEFAULT: Dict[ARConfigKey, Callable[[Any], Any]] = {
+    ARConfigKey.OPTIMISTIC_DATA: safe_bool_config,
+    ARConfigKey.OPTIMISTIC_TEMPERATURE: safe_bool_config,
+    ARConfigKey.ROBUST_BOOTTIME: safe_bool_config,
+}
+
+
 class Config:
     """Configuration class for AsusRouter."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self, defaults: Optional[Dict[ARConfigKey, Any]] = None
+    ) -> None:
         """Initialize the configuration."""
 
         self._lock = threading.Lock()
 
-        self._options: Dict[str, Any] = {
-            "optimistic_data": CONFIG_DEFAULT_BOOL,
-            "optimistic_temperature": CONFIG_DEFAULT_BOOL,
-            # If set, the boottime will be processed with 2 seconds
-            # precision to avoid +- 1 second uncertainty in the raw data.
-            "robust_boottime": CONFIG_DEFAULT_BOOL,
+        defaults = defaults or CONFIG_DEFAULT
+        self._options: Dict[ARConfigKey, Any] = {
+            key: defaults.get(key, None) for key in ARConfigKey
         }
-        self._types: Dict[str, Callable[[Any], Any]] = {}
+        self._types: Dict[ARConfigKey, Callable[[Any], Any]] = {
+            key: TYPES_DEFAULT.get(key, safe_bool_config)
+            for key in ARConfigKey
+        }
 
-    def set(self, key: str, value: Any) -> None:
+    def set(self, key: ARConfigKey, value: Any) -> None:
         """Set the configuration option."""
 
         with self._lock:
-            if key in self._options:
+            if isinstance(key, ARConfigKey) and key in self._options:
                 converter: Callable[[Any], Any] = self._types.get(
                     key, safe_bool_config
                 )
@@ -50,38 +77,51 @@ class Config:
             else:
                 raise KeyError(f"Unknown configuration option: {key}")
 
-    def get(self, key: str) -> Any:
+    def get(self, key: ARConfigKey) -> Any:
         """Get the configuration option."""
 
         with self._lock:
-            if key in self._options:
+            if isinstance(key, ARConfigKey) and key in self._options:
                 return self._options[key]
             else:
                 raise KeyError(f"Unknown configuration option: {key}")
 
-    def keys(self) -> list[str]:
+    def keys(self) -> list[ARConfigKey]:
         """Get the list of configuration keys."""
 
         with self._lock:
             return list(self._options.keys())
 
+    def reset(self) -> None:
+        """Reset all configuration options to their default values."""
+
+        with self._lock:
+            for key in ARConfigKey:
+                self._options[key] = CONFIG_DEFAULT.get(key, None)
+                self._types[key] = TYPES_DEFAULT.get(key, safe_bool_config)
+
+    def register_type(
+        self, key: ARConfigKey, converter: Callable[[Any], Any]
+    ) -> None:
+        """Register a custom converter for a config key."""
+
+        if not isinstance(key, ARConfigKey):
+            raise KeyError(f"Unknown configuration key: {key}")
+
+        with self._lock:
+            self._types[key] = converter
+
+    def __contains__(self, key: ARConfigKey) -> bool:
+        """Check if a configuration key exists."""
+
+        return key in self._options
+
     @property
-    def optimistic_data(self) -> bool:
-        """Get the optimistic data flag."""
+    def types(self) -> Dict[ARConfigKey, Callable[[Any], Any]]:
+        """Get the dictionary of configuration types."""
 
-        return bool(self.get("optimistic_data"))
-
-    @property
-    def optimistic_temperature(self) -> bool:
-        """Get the optimistic temperature flag."""
-
-        return bool(self.get("optimistic_temperature"))
-
-    @property
-    def robust_boottime(self) -> bool:
-        """Get the robust boottime flag."""
-
-        return bool(self.get("robust_boottime"))
+        with self._lock:
+            return self._types.copy()
 
 
 ARConfig: Config = Config()

--- a/asusrouter/modules/endpoint/devicemap.py
+++ b/asusrouter/modules/endpoint/devicemap.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Tuple
 
 import xmltodict
 
-from asusrouter.config import ARConfig
+from asusrouter.config import ARConfig, ARConfigKey
 from asusrouter.modules.data import AsusData, AsusDataState
 from asusrouter.modules.endpoint import data_get
 from asusrouter.modules.openvpn import AsusOVPNClient, AsusOVPNServer
@@ -189,7 +189,7 @@ def read_uptime_string(
     # If robust_boottime is enabled, floor the uptime to even seconds
     # This will introduce a systematic error with up to 1 second delay
     # but will avoid raw data uncertainty and the resulting jitter
-    if ARConfig.robust_boottime:
+    if ARConfig.get(ARConfigKey.ROBUST_BOOTTIME) is True:
         even_seconds = uptime.second - (uptime.second % 2)
         uptime = uptime.replace(second=even_seconds, microsecond=0)
 
@@ -199,7 +199,7 @@ def read_uptime_string(
 def process(data: dict[str, Any]) -> dict[AsusData, Any]:
     """Process data from devicemap endpoint."""
 
-    # Get the passed awrguments
+    # Get the passed arguments
     history: dict[AsusData, AsusDataState] = data_get(data, "history") or {}
 
     # Devicemap - just the data itself

--- a/asusrouter/modules/endpoint/temperature.py
+++ b/asusrouter/modules/endpoint/temperature.py
@@ -6,7 +6,7 @@ import logging
 import threading
 from typing import Any, Optional
 
-from asusrouter.config import ARConfig
+from asusrouter.config import ARConfig, ARConfigKey
 from asusrouter.modules.data import AsusData
 from asusrouter.modules.wlan import Wlan
 from asusrouter.tools.cleaners import clean_content
@@ -84,7 +84,7 @@ def read(content: str) -> dict[str, Any]:
 
     # While this functional is performing a kind of post-processing,
     # it should stay a part of the read method to have access to the raw data
-    if ARConfig.optimistic_temperature is True:
+    if ARConfig.get(ARConfigKey.OPTIMISTIC_TEMPERATURE) is True:
         temperature, scaled = _scale_temperature(temperature)
         with _temperature_warned_lock:
             if scaled and _temperature_warned is False:

--- a/asusrouter/modules/endpoint/temperature.py
+++ b/asusrouter/modules/endpoint/temperature.py
@@ -84,7 +84,7 @@ def read(content: str) -> dict[str, Any]:
 
     # While this functional is performing a kind of post-processing,
     # it should stay a part of the read method to have access to the raw data
-    if ARConfig.get(ARConfigKey.OPTIMISTIC_TEMPERATURE) is True:
+    if ARConfig.get(ARConfigKey.OPTIMISTIC_TEMPERATURE):
         temperature, scaled = _scale_temperature(temperature)
         with _temperature_warned_lock:
             if scaled and _temperature_warned is False:

--- a/tests/modules/endpoint/test_devicemap.py
+++ b/tests/modules/endpoint/test_devicemap.py
@@ -5,6 +5,7 @@ from typing import Any, Generator, Optional, Tuple
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from asusrouter.config import ARConfigKey
 from asusrouter.modules.data import AsusData, AsusDataState
 from asusrouter.modules.endpoint import devicemap
 
@@ -284,9 +285,11 @@ def test_read_uptime_string_robust(
 
     # Mock the ARConfig to enable robust boottime
     with patch(
-        "asusrouter.modules.endpoint.devicemap.ARConfig",
-        new=MagicMock(robust_boottime=True),
-    ):
+        "asusrouter.modules.endpoint.devicemap.ARConfig"
+    ) as mock_config:
+        mock_config.get.side_effect = (
+            lambda key: True if key == ARConfigKey.ROBUST_BOOTTIME else False
+        )
         # Test with a valid content string
         content = f"Sat, 8 Aug 2025 08:08:{raw_seconds} "
         content += f"+0100({diff_seconds} secs since boot)"

--- a/tests/modules/endpoint/test_temperature.py
+++ b/tests/modules/endpoint/test_temperature.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from unittest.mock import call, patch
 
 import pytest
-from asusrouter.config import ARConfig
+from asusrouter.config import ARConfig, ARConfigKey
 from asusrouter.modules.data import AsusData
 from asusrouter.modules.endpoint import temperature as temp_mod
 from asusrouter.modules.endpoint.temperature import _scale_temperature, process
@@ -15,7 +15,7 @@ from asusrouter.modules.wlan import Wlan
 def reset_config() -> None:
     """Reset the configuration before each test."""
 
-    ARConfig.set("optimistic_temperature", False)
+    ARConfig.set(ARConfigKey.OPTIMISTIC_TEMPERATURE, False)
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,7 @@ def test_read_mocked(
 ) -> None:
     """Test the read function."""
 
-    ARConfig.set("optimistic_temperature", optimistic)
+    ARConfig.set(ARConfigKey.OPTIMISTIC_TEMPERATURE, optimistic)
     temp_mod._temperature_warned = False
 
     with (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import random
+from typing import Any
+
 import pytest
-from asusrouter.config import CONFIG_DEFAULT_BOOL, ARConfig, safe_bool_config
+from asusrouter.config import (
+    CONFIG_DEFAULT_BOOL,
+    TYPES_DEFAULT,
+    ARConfig,
+    ARConfigKey,
+    safe_bool_config,
+)
 
 KEYS_BOOL = [
-    "optimistic_data",
+    ARConfigKey.OPTIMISTIC_DATA,
+    ARConfigKey.OPTIMISTIC_TEMPERATURE,
+    ARConfigKey.ROBUST_BOOTTIME,
 ]
 
 
@@ -14,18 +26,229 @@ KEYS_BOOL = [
 def reset_config() -> None:
     """Reset the configuration before each test."""
 
-    ARConfig.set("optimistic_data", CONFIG_DEFAULT_BOOL)
-    ARConfig.set("optimistic_temperature", CONFIG_DEFAULT_BOOL)
+    ARConfig.set(ARConfigKey.OPTIMISTIC_DATA, CONFIG_DEFAULT_BOOL)
+    ARConfig.set(ARConfigKey.OPTIMISTIC_TEMPERATURE, CONFIG_DEFAULT_BOOL)
+    ARConfig.set(ARConfigKey.ROBUST_BOOTTIME, CONFIG_DEFAULT_BOOL)
+
+
+class TestConfig:
+    """Tests for the ARConfig class."""
+
+    def test_custom_defaults(self) -> None:
+        """Test that custom defaults can be set and retrieved correctly."""
+
+        custom = {ARConfigKey.OPTIMISTIC_DATA: True}
+        config = type(ARConfig)(custom)
+        assert config.get(ARConfigKey.OPTIMISTIC_DATA) is True
+
+    @pytest.mark.parametrize(
+        "wrong_key",
+        [
+            "unknown_option",
+            12345,
+            ["a", "b"],
+            object(),
+            None,
+        ],
+    )
+    def test_wrong_key(self, wrong_key: Any) -> None:
+        """Test that setting/getting an unknown key raises KeyError."""
+
+        with pytest.raises(KeyError):
+            ARConfig.set(wrong_key, True)
+
+        with pytest.raises(KeyError):
+            ARConfig.get(wrong_key)
+
+    def test_contains(self) -> None:
+        """Test the __contains__ method for ARConfig."""
+
+        for key in KEYS_BOOL:
+            assert key in ARConfig
+        assert "not_a_key" not in ARConfig  # type: ignore[operator]
+
+    def test_keys(self) -> None:
+        """Test that we can get the full list of configuration keys."""
+
+        keys = ARConfig.keys()
+        assert isinstance(keys, list)
+        assert len(keys) > 0
+        assert all(isinstance(key, ARConfigKey) for key in keys)
+
+    def test_keys_immutable(self) -> None:
+        """Test that the keys list is immutable."""
+
+        keys = ARConfig.keys()
+        keys.append("something")  # type: ignore[arg-type]
+        assert all(isinstance(key, ARConfigKey) for key in ARConfig.keys())
+
+    def test_keys_returns_all_enum_members(self) -> None:
+        """Test that ARConfig.keys() returns all members of ARConfigKey."""
+
+        keys = set(ARConfig.keys())
+        enum_keys = set(ARConfigKey)
+        assert keys == enum_keys
+
+    def test_types(self) -> None:
+        """Test that we can get the types of configuration keys."""
+
+        types = ARConfig.types
+        assert isinstance(types, dict)
+        assert len(types) > 0
+        assert all(isinstance(key, ARConfigKey) for key in types.keys())
+        assert all(callable(converter) for converter in types.values())
+
+
+class TestRegisterType:
+    """Tests for the register_type method of ARConfig."""
+
+    def test_register_type(self) -> None:
+        """Test that we can register a new type for a configuration key."""
+
+        def int_to_bool(val: Any) -> bool:
+            """Convert a string to an integer to a boolean."""
+
+            return bool(int(val))
+
+        ARConfig.register_type(ARConfigKey.OPTIMISTIC_DATA, int_to_bool)
+        ARConfig.set(ARConfigKey.OPTIMISTIC_DATA, 1)
+        assert ARConfig.get(ARConfigKey.OPTIMISTIC_DATA) is True
+        ARConfig.set(ARConfigKey.OPTIMISTIC_DATA, 0)
+        assert ARConfig.get(ARConfigKey.OPTIMISTIC_DATA) is False
+
+        # Restore original converter for cleanliness
+        ARConfig.register_type(ARConfigKey.OPTIMISTIC_DATA, safe_bool_config)
+
+    def test_register_type_overwrites_existing(self) -> None:
+        """Test that register_type overwrites an existing converter."""
+
+        def always_true(val: Any) -> bool:
+            return True
+
+        def always_false(val: Any) -> bool:
+            return False
+
+        ARConfig.register_type(ARConfigKey.OPTIMISTIC_DATA, always_true)
+        ARConfig.set(ARConfigKey.OPTIMISTIC_DATA, "anything")
+        assert ARConfig.get(ARConfigKey.OPTIMISTIC_DATA) is True
+
+        ARConfig.register_type(ARConfigKey.OPTIMISTIC_DATA, always_false)
+        ARConfig.set(ARConfigKey.OPTIMISTIC_DATA, "anything")
+        assert ARConfig.get(ARConfigKey.OPTIMISTIC_DATA) is False
+
+        # Restore original converter
+        ARConfig.register_type(ARConfigKey.OPTIMISTIC_DATA, safe_bool_config)
+
+    def test_register_type_unknown_key(self) -> None:
+        """Test that register_type raises KeyError for unknown keys."""
+
+        class FakeKey:
+            pass
+
+        with pytest.raises(KeyError):
+            ARConfig.register_type(FakeKey(), lambda x: x)  # type: ignore[arg-type]
+
+
+class TestReset:
+    """Tests for the reset method of ARConfig."""
+
+    def test_reset(self) -> None:
+        """Test that reset restores all configuration options and types."""
+
+        # Change all values
+        for key in KEYS_BOOL:
+            ARConfig.set(key, not CONFIG_DEFAULT_BOOL)
+            assert ARConfig.get(key) is not CONFIG_DEFAULT_BOOL
+
+        # Change a type
+        for key in KEYS_BOOL:
+            ARConfig.register_type(key, lambda x: not x)
+            assert ARConfig.get(key) is not CONFIG_DEFAULT_BOOL
+
+        # Reset to defaults
+        ARConfig.reset()
+        for key in KEYS_BOOL:
+            assert ARConfig.get(key) is CONFIG_DEFAULT_BOOL
+            assert ARConfig.types[key] is TYPES_DEFAULT[key]
+
+
+class TestThreadSafety:
+    """Tests for thread safety of ARConfig."""
+
+    def test_set_and_get(self) -> None:
+        """Test thread safety for set and get."""
+
+        def set_and_get(key: ARConfigKey, val: Any) -> Any:
+            """Set a value and return it."""
+
+            ARConfig.set(key, val)
+            return key, ARConfig.get(key)
+
+            # Prepare a list of (key, value) pairs
+
+        tasks = [
+            (random.choice(KEYS_BOOL), random.choice([True, False]))
+            for _ in range(100)
+        ]
+
+        # Run many concurrent set/get operations
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            results = list(executor.map(lambda kv: set_and_get(*kv), tasks))
+
+        # Check that all results are as expected
+        for (key, expected_val), (result_key, result_val) in zip(
+            tasks, results
+        ):
+            assert key == result_key
+            assert result_val == expected_val
+
+    def test_register_type(self) -> None:
+        """Test thread safety for register_type."""
+
+        def register() -> None:
+            """Register a type."""
+            ARConfig.register_type(
+                ARConfigKey.OPTIMISTIC_DATA, safe_bool_config
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(register) for _ in range(20)]
+            for f in futures:
+                f.result()
+
+    def test_reset(self) -> None:
+        """Test thread safety for reset."""
+
+        def reset_config() -> None:
+            """Reset the configuration."""
+            ARConfig.reset()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(reset_config) for _ in range(20)]
+            for f in futures:
+                f.result()
 
 
 class TestConvert:
     """Tests for the configuration conversion functions."""
 
-    @pytest.mark.parametrize("value", [True, False])
-    def test_safe_bool_config(self, value: bool) -> None:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("false", False),
+            (1, True),
+            (0, False),
+            ("1", True),
+            ("0", False),
+        ],
+    )
+    def test_safe_bool_config(self, value: Any, expected: bool) -> None:
         """Test that safe_bool_config converts values correctly."""
 
-        assert safe_bool_config(value) is value
+        assert safe_bool_config(value) is expected
 
     def test_safe_bool_config_default(self) -> None:
         """Test that safe_bool_config returns default when value is None."""
@@ -36,43 +259,16 @@ class TestConvert:
 class TestBoolConfig:
     """Tests for boolean configuration options."""
 
-    def test_keys(self) -> None:
-        """Test that we can get the full list of configuration keys."""
-
-        keys = ARConfig.keys()
-        assert isinstance(keys, list)
-        assert len(keys) > 0
-        assert all(isinstance(key, str) for key in keys)
-
     @pytest.mark.parametrize("key", KEYS_BOOL)
-    def test_default_bool(self, key: str) -> None:
+    def test_default_bool(self, key: ARConfigKey) -> None:
         """Test the default value of a boolean configuration key."""
 
         assert ARConfig.get(key) is CONFIG_DEFAULT_BOOL
 
     @pytest.mark.parametrize("key", KEYS_BOOL)
     @pytest.mark.parametrize("value", [True, False])
-    def test_set_bool(self, key: str, value: bool) -> None:
+    def test_set_bool(self, key: ARConfigKey, value: bool) -> None:
         """Test setting a boolean configuration key."""
 
         ARConfig.set(key, value)
         assert ARConfig.get(key) is value
-
-    def test_get_optimistic_data(self) -> None:
-        """Test that we can get the value of optimistic_data."""
-
-        assert ARConfig.optimistic_data is CONFIG_DEFAULT_BOOL
-
-    def test_get_optimistic_temperature(self) -> None:
-        """Test that we can get the value of optimistic_temperature."""
-
-        assert ARConfig.optimistic_temperature is CONFIG_DEFAULT_BOOL
-
-    def test_unknown_key(self) -> None:
-        """Test that setting/getting an unknown key raises KeyError."""
-
-        with pytest.raises(KeyError):
-            ARConfig.set("unknown_option", True)
-
-        with pytest.raises(KeyError):
-            ARConfig.get("unknown_option")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -184,8 +184,7 @@ class TestThreadSafety:
             ARConfig.set(key, val)
             return key, ARConfig.get(key)
 
-            # Prepare a list of (key, value) pairs
-
+        # Prepare a list of (key, value) pairs
         tasks = [
             (random.choice(KEYS_BOOL), random.choice([True, False]))
             for _ in range(100)


### PR DESCRIPTION
This PR breaks the previous possibility to get Config properties via separate getters. Now, only the `get` method with the correct ARConfigKey should be used, which improves robustness