### PR TITLE
Add safeguard to the process data call

### DIFF
--- a/asusrouter/modules/endpoint/__init__.py
+++ b/asusrouter/modules/endpoint/__init__.py
@@ -190,10 +190,20 @@ def process(
             data_set(data, wlan=wlan)
 
         # Process the data
-        result = submodule.process(data)
-        if isinstance(result, dict):
-            return result
-        return {}
+        try:
+            result = submodule.process(data)
+            if isinstance(result, dict):
+                return result
+            return {}
+        # Consider attribute and value errors to be possible
+        # in case of unexpected data structure
+        except (AttributeError, ValueError) as ex:
+            _LOGGER.error(
+                "Error processing data from endpoint %s: %s",
+                endpoint,
+                ex,
+            )
+            return {}
 
     return {}
 

--- a/tests/modules/endpoint/test_endpoint.py
+++ b/tests/modules/endpoint/test_endpoint.py
@@ -232,6 +232,27 @@ def test_process_module_return_fail() -> None:
         mock_get_module.assert_called_once_with(Endpoint.DEVICEMAP)
 
 
+@pytest.mark.parametrize(
+    ("error"),
+    [
+        AttributeError,
+        ValueError,
+    ],
+)
+def test_process_module_raises(error: type[Exception]) -> None:
+    """Test process method when an exception is raised."""
+
+    mock_module = MagicMock()
+    mock_module.process.side_effect = error
+
+    with patch(
+        "asusrouter.modules.endpoint._get_module", return_value=mock_module
+    ) as mock_get_module:
+        result = process(Endpoint.DEVICEMAP, {"key": "value"})
+        assert result == {}
+        mock_get_module.assert_called_once_with(Endpoint.DEVICEMAP)
+
+
 def test_data_set() -> None:
     """Test data_set function."""
 


### PR DESCRIPTION
This will ensure that the data process fail won't cause a package-wide failure