### PR TITLE
Catch OverflowError in safe_timestamp_to_utc for 32-bit platforms

### DIFF
--- a/asusrouter/tools/converters.py
+++ b/asusrouter/tools/converters.py
@@ -619,10 +619,10 @@ def safe_timestamp_to_utc(value: int | None) -> datetime | None:
 
     try:
         return datetime.fromtimestamp(value, UTC)
-    except (ValueError, TypeError, OSError):
+    except (OverflowError, ValueError, TypeError, OSError):
         try:
             return datetime.fromtimestamp(value / 1000, UTC)
-        except (ValueError, TypeError, OSError):
+        except (OverflowError, ValueError, TypeError, OSError):
             return None
 
 


### PR DESCRIPTION
On 64-bit systems, datetime.fromtimestamp(1700515143689, UTC) raises ValueError ("year is out of range"), which is caught and falls through to the millisecond fallback (value / 1000). On 32-bit platforms such as i386, time_t is 32-bit and the same call raises OverflowError ("timestamp out of range for platform time_t"), which was not in the except tuple, so it propagated instead of falling through.

Add OverflowError to both except clauses so the millisecond fallback is reached on 32-bit platforms, fixing test_safe_timestamp_to_utc on i386.