### PR TITLE
Fix wireless client misclassification on AiMesh root mesh node

### DIFF
--- a/asusrouter/modules/client.py
+++ b/asusrouter/modules/client.py
@@ -140,8 +140,13 @@ CLIENT_MAP_DESCRIPTION: dict[str, list[MapValueType]] = {
 
 CLIENT_MAP_CONNECTION: dict[str, list[MapValueType]] = {
     "type": [
-        ("connection_type", get_connection_type),
+        # `isWL` from update_clients.asp is the canonical wireless-band signal
+        # ("1"=2.4G, "2"=5G, "3"=5G2, "4"=6G); it must be consulted before
+        # `connection_type`, which is derived from `ajax_onboarding.asp` and
+        # can be a stale or incorrect 0 (WIRED) for wireless clients on the
+        # root mesh node — see issues #800, #874, #1124 in ha-asusrouter.
         ("isWL", get_connection_type),
+        ("connection_type", get_connection_type),
     ],
     "ip_address": [
         ("ip"),
@@ -169,8 +174,12 @@ CLIENT_MAP_CONNECTION: dict[str, list[MapValueType]] = {
 
 CLIENT_MAP_CONNECTION_WLAN: dict[str, list[MapValueType]] = {
     "guest_id": [
-        ("guest"),
+        # `isGN` from update_clients.asp is the canonical guest-network signal
+        # for the AP a client is actually associated with; it must be consulted
+        # before `guest`, which is derived from `ajax_onboarding.asp` and is
+        # 0 for any wireless client that the root mesh node mis-buckets as wired.
         ("isGN", safe_int),
+        ("guest"),
     ],
     "rssi": [
         ("rssi", safe_int),

--- a/tests/modules/test_client.py
+++ b/tests/modules/test_client.py
@@ -524,3 +524,84 @@ def test_process_history(
 
     # Check the result
     assert result == data[expected_result]
+
+
+# Regression tests for CLIENT_MAP_CONNECTION precedence (issues #800/#874/#1124
+# in ha-asusrouter): on AiMesh systems, wireless clients connected to the root
+# mesh node can land in the `wired_mac` bucket of `ajax_onboarding.asp`, which
+# makes the onboarding-derived `connection_type` field a misleading 0 (WIRED).
+# `isWL` and `isGN` from `update_clients.asp` are the canonical signals and
+# must take precedence.
+@pytest.mark.parametrize(
+    ("data", "expected_type"),
+    [
+        # Both signals present, isWL says 2.4G — isWL wins (was: WIRED).
+        (
+            {"connection_type": 0, "isWL": "1"},
+            ConnectionType.WLAN_2G,
+        ),
+        # Both signals present, isWL says 6G — isWL wins.
+        (
+            {"connection_type": 0, "isWL": "4"},
+            ConnectionType.WLAN_6G,
+        ),
+        # Only isWL — used directly.
+        (
+            {"isWL": "2"},
+            ConnectionType.WLAN_5G,
+        ),
+        # Only connection_type — falls back (wired client with no isWL).
+        (
+            {"connection_type": 2},
+            ConnectionType.WLAN_5G,
+        ),
+        # isWL "0" (truly wired, isWL is explicitly zero) — wins as WIRED.
+        (
+            {"connection_type": 0, "isWL": "0"},
+            ConnectionType.WIRED,
+        ),
+    ],
+)
+def test_client_map_connection_type_precedence(
+    data: dict[str, Any], expected_type: ConnectionType
+) -> None:
+    """isWL must take precedence over connection_type in CLIENT_MAP_CONNECTION."""
+
+    result = process_data(data, CLIENT_MAP_CONNECTION, AsusClientConnection())
+    assert result.type == expected_type
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_guest_id"),
+    [
+        # Both signals present, isGN says guest network 2 — isGN wins (was: 0).
+        (
+            {"guest": 0, "isGN": "2"},
+            2,
+        ),
+        # Only isGN — used directly.
+        (
+            {"isGN": "1"},
+            1,
+        ),
+        # Only `guest` from onboarding — falls back.
+        (
+            {"guest": 3},
+            3,
+        ),
+        # isGN "0" (main network) — wins over a stale `guest` value.
+        (
+            {"guest": 1, "isGN": "0"},
+            0,
+        ),
+    ],
+)
+def test_client_map_connection_wlan_guest_id_precedence(
+    data: dict[str, Any], expected_guest_id: int
+) -> None:
+    """isGN must take precedence over `guest` in CLIENT_MAP_CONNECTION_WLAN."""
+
+    result = process_data(
+        data, CLIENT_MAP_CONNECTION_WLAN, AsusClientConnectionWlan()
+    )
+    assert result.guest_id == expected_guest_id


### PR DESCRIPTION
## Summary

Wireless clients connected to the **root** mesh node of an AiMesh
system have been silently classified as `WIRED` on the `connected_devices`
sensor and `device_tracker.*` attributes, regardless of which band
(2.4 / 5 / 6 GHz) they're actually associated with. Several open issues
describe this from different hardware (RT-AX86S, RT-AC88U, RT-AX88U Pro)
and this PR closes them with a minimal, low-risk fix.

Validated on hardware: ZenWiFi BT8 3-node mesh, FW `3.0.0.6.102_58407`,
asusrouter `1.21.3`.

Closes Vaskivskyi/ha-asusrouter#800
Closes Vaskivskyi/ha-asusrouter#874
Closes Vaskivskyi/ha-asusrouter#1124

## Root cause

Three issues compound:

1. **Router-side data quirk** (out of scope here, just context): on at
   least the ZenWiFi BT8, the root mesh node's `ajax_onboarding.asp`
   response puts every wireless client of the root into the `wired_mac`
   array — not into the `2G_1` / `5G_1` / `6G_1` sub-objects. Clients
   that have associated with a *satellite* node are bucketed correctly.

2. **String-vs-int dict lookup in `process_connection`**
   (`asusrouter/modules/endpoint/onboarding.py:130`):

   ```python
   "connection_type": CONNECTION_TYPE.get(temp[0]) or 0,
   ```

   `temp[0]` is a string like `"2G"`, `"5G"`, `"6G"` (from
   `data.split("_")`). `CONNECTION_TYPE` is an integer-keyed dict
   (`{0: WIRED, 1: WLAN_2G, 2: WLAN_5G, 3: WLAN_5G2, 4: WLAN_6G}`), so
   the lookup always returns `None` and the `or 0` falls to `WIRED`.
   Every wireless client routed through this code path picks up
   `connection_type: 0`.

3. **Precedence in `CLIENT_MAP_CONNECTION`**
   (`asusrouter/modules/client.py:141-145`):

   ```python
   "type": [
       ("connection_type", get_connection_type),  # corrupted by (2)
       ("isWL", get_connection_type),             # correct, never reached
   ],
   ```

   `process_data` iterates the list and breaks on the first non-`None`
   value. `connection_type` is always present (set to 0 by the broken
   path), so the loop never falls through to the canonical `isWL` field
   from `update_clients.asp`. Same shape of bug in
   `CLIENT_MAP_CONNECTION_WLAN["guest_id"]` (`guest` before `isGN`).

## The fix

Swap the two pairs so the canonical `update_clients.asp` signals win:

```diff
 "type": [
-    ("connection_type", get_connection_type),
     ("isWL", get_connection_type),
+    ("connection_type", get_connection_type),
 ],
```

```diff
 "guest_id": [
-    ("guest"),
     ("isGN", safe_int),
+    ("guest"),
 ],
```

The fallback pairs are retained, so anything that was working before
this swap continues to work — only the precedence changes.

### Why this is safe for wired clients

`isWL` is provided by `update_clients.asp` for every client. For wired
clients it's either absent or the string `"0"`. `get_connection_type("0")`
returns `ConnectionType.WIRED`, and absent-key falls through to the
existing `connection_type` path. Wired classification is preserved.

### Why this is safe for wireless clients on satellite nodes

These were already correctly classified pre-patch (their satellite
section in `onboarding.py` populates the right `connection_type`).
After this PR they're still correct — the `isWL` from
`update_clients.asp` matches what `onboarding.py` was producing.

### Why a minimal fix here, not in `process_connection`

A separate, deeper bug in `process_connection`'s string-vs-int lookup
(item 2 above) is real, but fixing it would change semantics in code
paths I can't fully test from one hardware sample. With this PR, that
function's output for `connection_type` becomes a never-consulted
fallback (since `isWL` always wins), so the bug stops manifesting in
user-visible behavior. If you'd like, I'm happy to follow up with a
PR for `process_connection` itself once we've agreed on the desired
band-string mapping.

## Tests

9 new parametrized cases in `tests/modules/test_client.py`:

- `test_client_map_connection_type_precedence` — 5 cases covering both
  signals present, single-signal-only cases, and the explicit `isWL="0"`
  wired case.
- `test_client_map_connection_wlan_guest_id_precedence` — 4 cases
  covering both signals present, single-signal-only cases, and `isGN="0"`
  beating a stale `guest` value.

Verified to **fail on the unpatched precedence** (4 cases — exactly the
ones where both signals are present and conflict) and **pass after the
swap**. Full suite: **1445 passed, 0 regressions**.

## Hardware tested

- **Validated:** ZenWiFi BT8 3-node mesh, stock FW `3.0.0.6.102_58407`.
  Before: 73 of 75 connected clients showed as `wired` despite being
  on Wi-Fi 6/6E radios. After: counts now match the router admin UI
  (2.4 / 5 / 6 GHz buckets correctly populated; only 2 actually-wired
  clients remain in `wired`).
- The fix should help all AiMesh deployments referenced in
  ha-asusrouter#800, #874, #1124 (RT-AX86S, RT-AX88U Pro, RT-AC88U,
  multiple reports).

## Notes

- Note that ZenWiFi BT8 is not currently in the tested-device list in
  the README; I'd be happy to provide additional data if useful for
  adding it.
- The `process_connection` deeper bug is happy-path follow-up; flagged
  above and tracked in my notes.
