### PR TITLE
fix: handle legacy port forwarding rules

### DIFF
--- a/asusrouter/modules/endpoint/hook.py
+++ b/asusrouter/modules/endpoint/hook.py
@@ -389,7 +389,7 @@ def process_port_forwarding(data: dict[str, Any]) -> dict[str, Any]:
                     ip_address=part[2],
                     port=safe_return(part[3]),
                     protocol=part[4],
-                    ip_external=safe_return(part[5]),
+                    ip_external=safe_return(part[5] if part[5:] else None),
                     port_external=part[1],
                 )
             )

--- a/tests/modules/test_port_forwarding.py
+++ b/tests/modules/test_port_forwarding.py
@@ -4,13 +4,38 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from asusrouter.modules.endpoint.hook import process_port_forwarding
 from asusrouter.modules.port_forwarding import (
+    KEY_PORT_FORWARDING_LIST,
     KEY_PORT_FORWARDING_STATE,
     AsusPortForwarding,
+    PortForwardingRule,
     set_state,
 )
 
 async_callback = AsyncMock()
+
+
+def test_rule_without_external_ip() -> None:
+    """A legacy five-field rule has no external IP restriction."""
+    result = process_port_forwarding(
+        {
+            KEY_PORT_FORWARDING_STATE: "1",
+            KEY_PORT_FORWARDING_LIST: (
+                "&#60Web&#6280&#62192.0.2.10&#628080&#62TCP"
+            ),
+        }
+    )
+
+    [rule] = result["rules"]
+    assert rule == PortForwardingRule(
+        name="Web",
+        ip_address="192.0.2.10",
+        port="8080",
+        protocol="TCP",
+        ip_external=None,
+        port_external="80",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- accept AsusWRT port-forwarding rows that omit the optional external source-IP column
- preserve the existing parsed representation by returning `None` for the missing restriction
- add a regression test using documentation-only IP addresses

## Why

Some AsusWRT firmware serializes unrestricted forwarding rules with five fields instead of a sixth empty source-IP field. The current parser indexes field 6 unconditionally, so one valid legacy rule prevents the entire port-forwarding state from loading.

## Testing

- `.venv/bin/pytest` — 1310 passed
- `.venv/bin/ruff check asusrouter/modules/endpoint/hook.py tests/modules/test_port_forwarding.py`
- `.venv/bin/ruff format --check asusrouter/modules/endpoint/hook.py tests/modules/test_port_forwarding.py`
- verified against AsusRouter 1.21.3 behavior
